### PR TITLE
Add validation and unlock handlers to purchase service

### DIFF
--- a/BuyKit.xcodeproj/xcshareddata/xcschemes/BuyKit-MacOS.xcscheme
+++ b/BuyKit.xcodeproj/xcshareddata/xcschemes/BuyKit-MacOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "E953A59D2335582A00A162F9"
-               BuildableName = "BuyKit_MacOS.framework"
+               BuildableName = "BuyKit.framework"
                BlueprintName = "BuyKit-MacOS"
                ReferencedContainer = "container:BuyKit.xcodeproj">
             </BuildableReference>
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -46,13 +44,11 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "E953A59D2335582A00A162F9"
-            BuildableName = "BuyKit_MacOS.framework"
+            BuildableName = "BuyKit.framework"
             BlueprintName = "BuyKit-MacOS"
             ReferencedContainer = "container:BuyKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -64,7 +60,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "E953A59D2335582A00A162F9"
-            BuildableName = "BuyKit_MacOS.framework"
+            BuildableName = "BuyKit.framework"
             BlueprintName = "BuyKit-MacOS"
             ReferencedContainer = "container:BuyKit.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
The validation handler is added so that the app can handle its own receipt validation to whatever degree desired and return a boolean of validity. The unlock features handler allows the app to unlock any purchased features and confirm success by returning a boolean so that the purchase won't be completed in the App Store without the user getting the goods.