### PR TITLE
Add validation and unlock handler step to restore purchases

### DIFF
--- a/BuyKit/PurchaseService.swift
+++ b/BuyKit/PurchaseService.swift
@@ -97,10 +97,14 @@ extension PurchaseService: SKPaymentTransactionObserver {
 
     private func restore(transaction: SKPaymentTransaction) {
         guard let _ = transaction.original?.payment.productIdentifier else { return }
-
-        ReceiptRepository.shared.recordPurchase(skProductId: transaction.payment.productIdentifier)
-
-        SKPaymentQueue.default().finishTransaction(transaction)
+        guard let unlockHandler = self.unlockFeaturesHandler else {
+            return
+        }
+        
+        if self.validationHandler(transaction) && unlockHandler(transaction) {
+            ReceiptRepository.shared.recordPurchase(skProductId: transaction.payment.productIdentifier)
+            SKPaymentQueue.default().finishTransaction(transaction)
+        }
     }
 
     private func fail(transaction: SKPaymentTransaction) {


### PR DESCRIPTION
This is to make restoring purchases similar to the buying step.
The restore function will now use the same validation handler
and unlock handler the app registers for the buy step, so that
the app will verify the receipt and unlock whatever is necessary.
However, unlike the buy function, it does not update observers.