### PR TITLE
Add starting and completed handlers for transaction queue processing

### DIFF
--- a/BuyKit/PurchaseService.swift
+++ b/BuyKit/PurchaseService.swift
@@ -8,6 +8,8 @@ open class PurchaseService: NSObject {
     public static let shared = PurchaseService()
     public var validationHandler: ((SKPaymentTransaction) -> Bool) = { _ in return true }
     public var unlockFeaturesHandler: ((SKPaymentTransaction) -> Bool)?
+    public var transactionProcessingStartingHandler: (([SKPaymentTransaction]) -> Void)?
+    public var transactionProcessingCompletedHandler: (() -> Void)?
     private var _canMakePayments: Bool?
     private var restoreCompletedHandler: ((Error?) -> Void)?
     private var observers: [WeakWrapper<PurchaseServiceObserver>] = []
@@ -45,7 +47,8 @@ open class PurchaseService: NSObject {
 
 extension PurchaseService: SKPaymentTransactionObserver {
     public func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
-
+        self.transactionProcessingStartingHandler?(transactions)
+        
         for transaction in transactions {
             print(" - transaction.transactionState: \(transaction.transactionState)")
             switch transaction.transactionState {
@@ -68,6 +71,8 @@ extension PurchaseService: SKPaymentTransactionObserver {
                 fatalError("Unhandled transaction state")
             }
         }
+        
+        self.transactionProcessingCompletedHandler?()
     }
 
     public func paymentQueueRestoreCompletedTransactionsFinished(_ queue: SKPaymentQueue) {


### PR DESCRIPTION
This gives the consumers of BuyKit the ability to hook into the start
of the transaction processing (and cancel it if desired) and also the
end. That way, they can validate a receipt/read it into memory without
validating every time. A completed hook allows teardown.